### PR TITLE
fix(auth): reduce session cookie size and improve auth reliability

### DIFF
--- a/src/app/api/oauth/callback/route.ts
+++ b/src/app/api/oauth/callback/route.ts
@@ -43,7 +43,6 @@ export async function GET(request: Request) {
       refreshToken: token.refresh_token,
       tokenType: token.token_type,
       scope: token.scope,
-      idToken: token.id_token,
       expiresAt: Date.now() + token.expires_in * 1000,
     });
 
@@ -91,7 +90,6 @@ export async function POST(request: Request) {
       refreshToken: token.refresh_token,
       tokenType: token.token_type,
       scope: token.scope,
-      idToken: token.id_token,
       expiresAt: Date.now() + token.expires_in * 1000,
     });
     return NextResponse.redirect(new URL(`${env.BASE_URL}/`, request.url));

--- a/src/app/api/oauth/logout/route.ts
+++ b/src/app/api/oauth/logout/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { clearSession } from "@/lib/session";
+import { env } from "@/env";
 
 export async function POST(request: Request) {
   await clearSession();
-  return NextResponse.redirect(new URL("/", request.url));
+  return NextResponse.redirect(new URL(`${env.BASE_URL}/`, request.url));
 }

--- a/src/app/callback/route.ts
+++ b/src/app/callback/route.ts
@@ -43,7 +43,6 @@ export async function GET(request: Request) {
       refreshToken: token.refresh_token,
       tokenType: token.token_type,
       scope: token.scope,
-      idToken: token.id_token,
       expiresAt: Date.now() + token.expires_in * 1000,
     });
 
@@ -91,7 +90,6 @@ export async function POST(request: Request) {
       refreshToken: token.refresh_token,
       tokenType: token.token_type,
       scope: token.scope,
-      idToken: token.id_token,
       expiresAt: Date.now() + token.expires_in * 1000,
     });
     return NextResponse.redirect(new URL(`${env.BASE_URL}/`, request.url));

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image";
 import { getCurrentUser } from "@/lib/fanvue";
 
+export const dynamic = "force-dynamic";
+
 export default async function Home({ searchParams }: { searchParams?: { [key: string]: string | string[] | undefined } }) {
   const me = await getCurrentUser();
   const isAuthed = !!me;

--- a/src/lib/fanvue.ts
+++ b/src/lib/fanvue.ts
@@ -9,16 +9,15 @@ export async function getCurrentUser() {
   if (Date.now() >= session.expiresAt - 30_000 && session.refreshToken) {
     try {
       const refreshed = await refreshAccessToken(session.refreshToken);
-      session = {
-        ...session,
+      const updatedSession = {
         accessToken: refreshed.access_token,
         refreshToken: refreshed.refresh_token ?? session.refreshToken,
         tokenType: refreshed.token_type,
         scope: refreshed.scope ?? session.scope,
-        idToken: refreshed.id_token ?? session.idToken,
         expiresAt: Date.now() + refreshed.expires_in * 1000,
       };
-      await setSession(session);
+      await setSession(updatedSession);
+      session = updatedSession;
     } catch {}
   }
 

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -39,7 +39,8 @@ export function getAuthorizeUrl({
     code_challenge_method: "S256",
   });
   if (env.OAUTH_RESPONSE_MODE) params.set("response_mode", env.OAUTH_RESPONSE_MODE);
-  if (env.OAUTH_PROMPT) params.set("prompt", env.OAUTH_PROMPT);
+  // Force login prompt to allow switching accounts
+  params.set("prompt", env.OAUTH_PROMPT || "login");
   return `${oauthConfig.issuerBaseURL}/oauth2/auth?${params.toString()}`;
 }
 

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -8,7 +8,6 @@ type SessionPayload = {
   expiresAt: number;
   tokenType?: string;
   scope?: string;
-  idToken?: string;
 };
 
 const encoder = new TextEncoder();


### PR DESCRIPTION
- Remove idToken from session storage to avoid exceeding 4KB cookie limit
- Use env.BASE_URL for logout redirect instead of relative URL
- Add force-dynamic to page.tsx to prevent stale user data