### PR TITLE
chore: migrate to @fanvue/builder-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@fanvue/auth": "^0.2.3",
+    "@fanvue/builder-sdk": "^0.3.0",
     "@t3-oss/env-nextjs": "^0.13.8",
     "jose": "^6.1.0",
     "next": "16.2.1",
@@ -29,7 +29,7 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "@fanvue/auth",
+      "@fanvue/builder-sdk",
       "@tailwindcss/oxide",
       "sharp",
       "unrs-resolver"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@fanvue/auth':
-        specifier: ^0.2.3
-        version: 0.2.3(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+      '@fanvue/builder-sdk':
+        specifier: ^0.3.0
+        version: 0.3.0(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@t3-oss/env-nextjs':
         specifier: ^0.13.8
         version: 0.13.8(typescript@5.9.2)(zod@4.1.7)
@@ -188,8 +188,8 @@ packages:
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@fanvue/auth@0.2.3':
-    resolution: {integrity: sha512-ZKSPCk2MxuUvdYKiGH9fHZFJOl/Xl21+BIElm7W1ym3kr8ts7kJyZ8VdBNHofvxSPecgwS1raW/JFsKMe8+hFw==}
+  '@fanvue/builder-sdk@0.3.0':
+    resolution: {integrity: sha512-kWpjeZepfQajI9tDX+jkqtBo8+9h62S7SYWafD+Pen1iWif/OeU3N+O4kH0QLn+hNpdGHx6DudL0wOhQaxoUIA==}
     peerDependencies:
       next: '>=14.0.0'
       react: '>=18.0.0'
@@ -2255,7 +2255,7 @@ snapshots:
       '@eslint/core': 0.15.2
       levn: 0.4.1
 
-  '@fanvue/auth@0.2.3(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
+  '@fanvue/builder-sdk@0.3.0(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     dependencies:
       jose: 6.1.0
       neverthrow: 8.2.0

--- a/src/app/api/fanvue/session/route.ts
+++ b/src/app/api/fanvue/session/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest } from "next/server";
 import {
   createConfig,
   createSessionExchangeHandler,
-} from "@fanvue/auth/nextjs/embedded-app";
+} from "@fanvue/builder-sdk/nextjs/embedded-app";
 
 // Deferred so createConfig() validates env vars at request time, not build time.
 let _handler: ReturnType<typeof createSessionExchangeHandler> | undefined;

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
-import { HEADER_UPDATED_SESSION } from "@fanvue/auth";
+import { HEADER_UPDATED_SESSION } from "@fanvue/builder-sdk";
 import {
   createConfig,
   getAuthenticatedClient,
-} from "@fanvue/auth/nextjs/embedded-app";
+} from "@fanvue/builder-sdk/nextjs/embedded-app";
 
 export async function GET() {
   const config = createConfig();

--- a/src/app/api/offline-test/route.ts
+++ b/src/app/api/offline-test/route.ts
@@ -5,8 +5,8 @@ import {
   createSessionJwt,
   HEADER_UPDATED_SESSION,
   type SessionPayload,
-} from "@fanvue/auth";
-import { createConfig, getSession } from "@fanvue/auth/nextjs/embedded-app";
+} from "@fanvue/builder-sdk";
+import { createConfig, getSession } from "@fanvue/builder-sdk/nextjs/embedded-app";
 
 const config = createConfig();
 

--- a/src/app/embedded/page.tsx
+++ b/src/app/embedded/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useAuth, useEmbeddedAuth } from "@fanvue/auth/react";
+import { useAuth, useEmbeddedAuth } from "@fanvue/builder-sdk/react";
 
 const FANVUE_GREEN = "#49f264";
 
@@ -173,7 +173,7 @@ export default function EmbeddedPage() {
 
         <footer className="text-center text-xs text-white/30">
           Powered by{" "}
-          <code className="font-mono text-white/50">@fanvue/auth</code>
+          <code className="font-mono text-white/50">@fanvue/builder-sdk</code>
         </footer>
       </main>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import { AuthProvider } from "@fanvue/auth/react";
+import { AuthProvider } from "@fanvue/builder-sdk/react";
 import "./globals.css";
 
 const geistSans = Geist({


### PR DESCRIPTION
## Summary

The SDK package was renamed `@fanvue/auth` → `@fanvue/builder-sdk`, and `@fanvue/builder-sdk@0.3.0` is now published on npm (same public API; 0.3.0 additively adds `theme` support). This app still imported the old name — this PR is a pure package-name migration.

## Changes

- `package.json`: dependency `@fanvue/auth@^0.2.3` → `@fanvue/builder-sdk@^0.3.0`, and the `pnpm.onlyBuiltDependencies` entry.
- Import paths in 5 source files (`/react`, `/nextjs/embedded-app` subpaths preserved).
- The user-visible "Powered by" label on the embedded page.
- `pnpm-lock.yaml` regenerated (resolves `@fanvue/builder-sdk@0.3.0` from npmjs.org).

No auth logic, env values, or flow changes.

## Verification

- `pnpm install` ✅ (resolved 0.3.0 from npm via the `@fanvue` scope mapping in `.npmrc`)
- `pnpm build` ✅ (Next.js production build + TypeScript pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)